### PR TITLE
Fixes environment name parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ create: conda-env
 # Create a conda environment from environment.yml
 conda-env:
 	@echo "Creating conda environment $(ENV_NAME) from $(ENV_FILE)..."
-	conda create  --name $(ENV_NAME) --file $(ENV_FILE)
+	conda env create  --name $(ENV_NAME) --file $(ENV_FILE)
 
 # Update a conda environment from environment.yml
 update:


### PR DESCRIPTION
Fixes error `CondaValueError: could not parse 'name: credit_card_defaults_prediction' in: environment.yml` when creating the virtual environment using make